### PR TITLE
Bump the mstest-dependencies group with 1 update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="BB84.Extensions" Version="3.0.722" />
 		<PackageVersion Include="BB84.Notifications" Version="3.6.531" />
-		<PackageVersion Include="MSTest" Version="3.10.0" />
+		<PackageVersion Include="MSTest" Version="3.10.1" />
 		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
 		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />


### PR DESCRIPTION
Bumps MSTest from 3.10.0 to 3.10.1

---
updated-dependencies:
- dependency-name: MSTest dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: mstest-dependencies ...