### PR TITLE
Bump the microsoft-dependencies group with 2 updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
 	<ItemGroup>
 		<PackageVersion Include="BB84.Extensions" Version="3.0.722" />
 		<PackageVersion Include="BB84.Notifications" Version="3.6.531" />
-		<PackageVersion Include="MSTest" Version="3.10.0" />
+		<PackageVersion Include="MSTest" Version="3.10.1" />
 		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
+		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Bumps Microsoft.Extensions.DependencyInjection from 9.0.7 to 9.0.8 Bumps Microsoft.Extensions.Hosting from 9.0.7 to 9.0.8

---
updated-dependencies:
- dependency-name: Microsoft.Extensions.DependencyInjection dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: microsoft-dependencies
- dependency-name: Microsoft.Extensions.Hosting dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: microsoft-dependencies ...