### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/Magic.Switch.Board/security/code-scanning/4](https://github.com/BoBoBaSs84/Magic.Switch.Board/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs build/test commands, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` field and before the `on` field. This will apply the least privilege principle to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
