### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: docs
+permissions:
+  contents: read
 
 on:
   push:
@@ -6,6 +8,8 @@ on:
 
 jobs:
     publish-docs:
+      permissions:
+        contents: write
       runs-on: windows-latest
       steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/Magic.Switch.Board/security/code-scanning/5](https://github.com/BoBoBaSs84/Magic.Switch.Board/security/code-scanning/5)

To fix the problem, add an explicit `permissions` block to the workflow. The best approach is to set the default permissions at the workflow level to `contents: read`, and then override it for the specific job (or step) that requires broader permissions. In this case, only the `publish-docs` job needs `contents: write` for the deployment step, so we can set `permissions: contents: write` at the job level. This ensures the workflow adheres to the principle of least privilege.

- Add a `permissions: contents: read` block at the top level of the workflow (after the `name` key).
- Add a `permissions: contents: write` block to the `publish-docs` job, since it needs to push to the `gh-pages` branch.

No new methods, imports, or definitions are needed; only YAML configuration changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
